### PR TITLE
Fixed issue with workers not unregistering as they should

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject resque-clojure "0.2.2"
+(defproject resque-clojure "0.2.3"
   :description "Redis based library for asynchronous processing"
   :url "https://github.com/jxa/resque-clojure"
   :dependencies [[org.clojure/data.json "0.2.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject resque-clojure "0.2.2"
   :description "Redis based library for asynchronous processing"
   :url "https://github.com/jxa/resque-clojure"
-  :dependencies [[org.clojure/data.json "0.1.2"]
+  :dependencies [[org.clojure/data.json "0.2.1"]
                  [redis.clients/jedis "1.5.2"]]
   :dev-dependencies [[org.clojure/clojure "1.3.0"]])

--- a/src/resque_clojure/supervisor.clj
+++ b/src/resque_clojure/supervisor.clj
@@ -26,7 +26,8 @@
 (defn stop []
   "stops polling queues. waits for all workers to complete current job"
   (dosync (ref-set run-loop? false))
-  (apply await-for (:max-shutdown-wait @config) @working-agents))
+  (apply await-for (:max-shutdown-wait @config) @working-agents)
+  (resque/unregister @watched-queues))
 
 (defn worker-complete [key ref old-state new-state]
   (release-worker ref)


### PR DESCRIPTION
We've hit this problem in production when there were tons of registered workers (thousands) while in reality there were 2 Clojure workers. Turned out that each time Clojure process called resque-clojure.supervisor/stop and exited the worker would still be left registered in Redis DB. This caused problems to how Ruby implementation of Resque client tries to clean up old workers - it started taking more than 30 seconds to start new worker with all these registered but non existing workers.

It looks like this is just a simple oversight, as obviously @watched-queues has the info necessary to unregister workers on stoppage.
