### PR TITLE
Add a note that timeout is set in milliseconds

### DIFF
--- a/src/resque_clojure/core.clj
+++ b/src/resque_clojure/core.clj
@@ -12,7 +12,7 @@
      :password
      :uri
      :database
-     :timeout
+     :timeout - in milliseconds
      :namespace
      :max-shutdown-wait
      :poll-interval


### PR DESCRIPTION
In redis config and ruby resque client timeout is set in seconds. Without getting inside the Jedis sources it was impossible to tell that it needs to be set in milliseconds for Jedis, so this caused us a lot of grief.
